### PR TITLE
Feat/add node12 support

### DIFF
--- a/node12/Dockerfile
+++ b/node12/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:12-alpine
+
+# Install build packages we want
+RUN apk add -Uuv git less zip build-base bash gettext curl \
+  && rm -rf /var/cache/apk/*
+
+# Install awscli
+RUN apk -v --update add \
+        python \
+        py-pip \
+        groff \
+        mailcap \
+    && \
+    pip install --upgrade awscli==1.14.5 s3cmd==2.0.1 python-magic && \
+    apk -v --purge del py-pip && \
+    rm /var/cache/apk/*
+
+# Install sentry-cli
+RUN curl -sL https://sentry.io/get-cli/ | bash
+
+# Install wait-for-it
+RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /opt/wait-for-it.sh \
+    && chmod +x /opt/wait-for-it.sh \
+    && ln -s /opt/wait-for-it.sh /usr/bin/wait-for-it

--- a/publish.sh
+++ b/publish.sh
@@ -8,6 +8,7 @@ GIT_SHORT_COMMIT="$(git rev-parse --short HEAD)"
 REPO_NAME="carimus/node-alpine-aws"
 NODE8_TAG="node8"
 NODE10_TAG="node10"
+NODE12_TAG="node12"
 
 if [[ -n "$GIT_STATUS" ]]; then
   echo "There are untracked changes or the working tree is dirty."
@@ -16,15 +17,26 @@ if [[ -n "$GIT_STATUS" ]]; then
 fi
 
 echo "Will build images with the following tags:"
-echo -e "Based on node:10-alpine:    $NODE10_TAG, latest, $GIT_SHORT_COMMIT, $GIT_SHORT_COMMIT-$NODE10_TAG"
+echo -e "Based on node:12-alpine:    $NODE12_TAG, latest, $GIT_SHORT_COMMIT, $GIT_SHORT_COMMIT-$NODE12_TAG"
+echo -e "Based on node:10-alpine:    $NODE10_TAG, $GIT_SHORT_COMMIT-$NODE10_TAG"
 echo -e "Based on node:8-alpine:     $NODE8_TAG, $GIT_SHORT_COMMIT-$NODE8_TAG"
+
 echo
 
-echo "Based on node:10-alpine (default image):"
+echo "Based on node:12-alpine (default image):"
 
-docker build -t $REPO_NAME:$NODE10_TAG \
+docker build -t $REPO_NAME:$NODE12_TAG \
   -t $REPO_NAME:latest \
   -t $REPO_NAME:$GIT_SHORT_COMMIT \
+  -t $REPO_NAME:$GIT_SHORT_COMMIT-$NODE12_TAG \
+  -f ./node12/Dockerfile \
+  .
+
+echo
+
+echo "Based on node:10-alpine:"
+
+docker build -t $REPO_NAME:$NODE10_TAG \
   -t $REPO_NAME:$GIT_SHORT_COMMIT-$NODE10_TAG \
   -f ./node10/Dockerfile \
   .
@@ -42,9 +54,11 @@ echo
 
 echo "Pushing images to docker hub:"
 
-docker push $REPO_NAME:$NODE10_TAG
+docker push $REPO_NAME:$NODE12_TAG
 docker push $REPO_NAME:latest
 docker push $REPO_NAME:$GIT_SHORT_COMMIT
+docker push $REPO_NAME:$GIT_SHORT_COMMIT-$NODE12_TAG
+docker push $REPO_NAME:$NODE10_TAG
 docker push $REPO_NAME:$GIT_SHORT_COMMIT-$NODE10_TAG
 docker push $REPO_NAME:$NODE8_TAG
 docker push $REPO_NAME:$GIT_SHORT_COMMIT-$NODE8_TAG

--- a/publish.sh
+++ b/publish.sh
@@ -17,26 +17,26 @@ if [[ -n "$GIT_STATUS" ]]; then
 fi
 
 echo "Will build images with the following tags:"
-echo -e "Based on node:12-alpine:    $NODE12_TAG, latest, $GIT_SHORT_COMMIT, $GIT_SHORT_COMMIT-$NODE12_TAG"
-echo -e "Based on node:10-alpine:    $NODE10_TAG, $GIT_SHORT_COMMIT-$NODE10_TAG"
+echo -e "Based on node:12-alpine:    $NODE12_TAG, $GIT_SHORT_COMMIT-$NODE12_TAG"
+echo -e "Based on node:10-alpine:    $NODE10_TAG, latest, $GIT_SHORT_COMMIT, $GIT_SHORT_COMMIT-$NODE10_TAG"
 echo -e "Based on node:8-alpine:     $NODE8_TAG, $GIT_SHORT_COMMIT-$NODE8_TAG"
 
 echo
 
-echo "Based on node:12-alpine (default image):"
+echo "Based on node:12-alpine:"
 
 docker build -t $REPO_NAME:$NODE12_TAG \
-  -t $REPO_NAME:latest \
-  -t $REPO_NAME:$GIT_SHORT_COMMIT \
   -t $REPO_NAME:$GIT_SHORT_COMMIT-$NODE12_TAG \
   -f ./node12/Dockerfile \
   .
 
 echo
 
-echo "Based on node:10-alpine:"
+echo "Based on node:10-alpine (default image):"
 
 docker build -t $REPO_NAME:$NODE10_TAG \
+  -t $REPO_NAME:latest \
+  -t $REPO_NAME:$GIT_SHORT_COMMIT \
   -t $REPO_NAME:$GIT_SHORT_COMMIT-$NODE10_TAG \
   -f ./node10/Dockerfile \
   .
@@ -55,10 +55,10 @@ echo
 echo "Pushing images to docker hub:"
 
 docker push $REPO_NAME:$NODE12_TAG
-docker push $REPO_NAME:latest
-docker push $REPO_NAME:$GIT_SHORT_COMMIT
 docker push $REPO_NAME:$GIT_SHORT_COMMIT-$NODE12_TAG
 docker push $REPO_NAME:$NODE10_TAG
+docker push $REPO_NAME:latest
+docker push $REPO_NAME:$GIT_SHORT_COMMIT
 docker push $REPO_NAME:$GIT_SHORT_COMMIT-$NODE10_TAG
 docker push $REPO_NAME:$NODE8_TAG
 docker push $REPO_NAME:$GIT_SHORT_COMMIT-$NODE8_TAG

--- a/update.sh
+++ b/update.sh
@@ -4,6 +4,8 @@ set -e
 
 mkdir -p ./node8/
 mkdir -p ./node10/
+mkdir -p ./node12/
 
 sed s/__BASE_IMAGE__/node:8-alpine/ < ./Dockerfile.template > ./node8/Dockerfile
 sed s/__BASE_IMAGE__/node:10-alpine/ < ./Dockerfile.template > ./node10/Dockerfile
+sed s/__BASE_IMAGE__/node:12-alpine/ < ./Dockerfile.template > ./node12/Dockerfile


### PR DESCRIPTION
### feat: add node12 support
Link to ticket: **No linked ticket**

### What has been done
- Add node12 support so we can publish new images to docker hub for the RigPark node12 upgrade.
- This PR keeps node10 as the default image while adding node 12 support